### PR TITLE
add shadow to item cell in home screen

### DIFF
--- a/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App.xcodeproj/project.pbxproj
+++ b/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		332EC50A2C50124000B46ACC /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332EC4F92C50124000B46ACC /* Utils.swift */; };
 		332EC50B2C50124000B46ACC /* GlobalFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332EC4FA2C50124000B46ACC /* GlobalFunctions.swift */; };
 		332EC50D2C50124000B46ACC /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332EC4FC2C50124000B46ACC /* ToastView.swift */; };
+		332F94EE2C60ADDC00CA68AB /* ShadowImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332F94ED2C60ADDC00CA68AB /* ShadowImageView.swift */; };
 		336174962C5CBAB800AFC7E0 /* ActorDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336174942C5CBAB800AFC7E0 /* ActorDetailViewController.swift */; };
 		336174972C5CBAB800AFC7E0 /* ActorDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 336174952C5CBAB800AFC7E0 /* ActorDetailViewController.xib */; };
 		3361749B2C5CBADD00AFC7E0 /* ActorDetailInfoItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336174992C5CBADD00AFC7E0 /* ActorDetailInfoItemCell.swift */; };
@@ -111,6 +112,7 @@
 		332EC4F92C50124000B46ACC /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		332EC4FA2C50124000B46ACC /* GlobalFunctions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlobalFunctions.swift; sourceTree = "<group>"; };
 		332EC4FC2C50124000B46ACC /* ToastView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		332F94ED2C60ADDC00CA68AB /* ShadowImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowImageView.swift; sourceTree = "<group>"; };
 		336174942C5CBAB800AFC7E0 /* ActorDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActorDetailViewController.swift; sourceTree = "<group>"; };
 		336174952C5CBAB800AFC7E0 /* ActorDetailViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ActorDetailViewController.xib; sourceTree = "<group>"; };
 		336174992C5CBADD00AFC7E0 /* ActorDetailInfoItemCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActorDetailInfoItemCell.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				33A663532C5272B300A6AAC6 /* KVCircleMenu */,
 				332EC4FC2C50124000B46ACC /* ToastView.swift */,
 				33BD24AF2C5E721100AA2E94 /* PieChartView.swift */,
+				332F94ED2C60ADDC00CA68AB /* ShadowImageView.swift */,
 			);
 			path = CommonView;
 			sourceTree = "<group>";
@@ -628,6 +631,7 @@
 				3387D02B2C577FCA00C96B7D /* CombinedCreditModel.swift in Sources */,
 				3374479A2C53A26300D01D1D /* APIService.swift in Sources */,
 				332EC50B2C50124000B46ACC /* GlobalFunctions.swift in Sources */,
+				332F94EE2C60ADDC00CA68AB /* ShadowImageView.swift in Sources */,
 				337447A42C53A27000D01D1D /* CreditModel.swift in Sources */,
 				3387D03C2C57870E00C96B7D /* BaseViewController.swift in Sources */,
 				33BD24B82C5FF32F00AA2E94 /* CoreDataUtils.swift in Sources */,

--- a/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/Utils/CommonView/ShadowImageView.swift
+++ b/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/Utils/CommonView/ShadowImageView.swift
@@ -1,0 +1,65 @@
+//
+//  ShadowImageView.swift
+//  HN_Pra19_IOS_Movie_App
+//
+//  Created by Khánh Vũ on 5/8/24.
+//
+
+import Foundation
+import UIKit
+
+class ShadowImageView: UIView {
+
+    private let imageView: UIImageView = UIImageView()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        addSubview(imageView)
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.layer.masksToBounds = true
+
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: self.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+    }
+
+    func setImage(_ image: UIImage?) {
+        imageView.image = image
+    }
+    
+    func setImage(_ urlStr: String) {
+        imageView.setImage(urlStr, nil)
+    }
+    
+    func setLayout(radius: CGFloat,
+                   shadowColor: UIColor?,
+                   shadowOpacity: Float,
+                   shadowOffset: CGSize,
+                   shadowRadius: CGFloat) {
+        imageView.layer.cornerRadius = radius
+        layer.shadowColor = shadowColor?.cgColor
+        layer.shadowOpacity = shadowOpacity
+        layer.shadowOffset = shadowOffset
+        layer.shadowRadius = shadowRadius
+        layer.cornerRadius = radius
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: 10).cgPath
+    }
+}
+

--- a/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/Utils/Extensions.swift
+++ b/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/Utils/Extensions.swift
@@ -202,6 +202,20 @@ extension UIImageView {
             completion?(img)
         }
     }
+    
+    func applyShadowAndCornerRadius(cornerRadius: CGFloat,
+                                    shadowColor: UIColor = .black,
+                                    shadowOpacity: Float = 0.5,
+                                    shadowOffset: CGSize = CGSize(width: 0, height: 2),
+                                    shadowRadius: CGFloat = 4) {
+        self.layer.cornerRadius = cornerRadius
+        self.layer.masksToBounds = false
+        self.layer.shadowColor = shadowColor.cgColor
+        self.layer.shadowOpacity = shadowOpacity
+        self.layer.shadowOffset = shadowOffset
+        self.layer.shadowRadius = shadowRadius
+        self.layer.shadowPath = UIBezierPath(roundedRect: self.bounds, cornerRadius: cornerRadius).cgPath
+    }
 }
 
 extension UITableView {

--- a/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/View/Home/Cell/HomeItemCell.swift
+++ b/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/View/Home/Cell/HomeItemCell.swift
@@ -9,9 +9,9 @@ import UIKit
 
 final class HomeItemCell: UICollectionViewCell {
 
-    @IBOutlet weak private var bottomImageView: UIImageView!
-    @IBOutlet weak private var midImageView: UIImageView!
-    @IBOutlet weak private var topImageView: UIImageView!
+    @IBOutlet weak private var bottomView: ShadowImageView!
+    @IBOutlet weak private var midView: ShadowImageView!
+    @IBOutlet weak private var topView: ShadowImageView!
     @IBOutlet weak private var nameLabel: UILabel!
     @IBOutlet weak private var dateLabel: UILabel!
     
@@ -28,15 +28,24 @@ final class HomeItemCell: UICollectionViewCell {
     private func setUpUI() {
         self.layer.masksToBounds = false
         self.contentView.layer.masksToBounds = false
-        bottomImageView.transform = CGAffineTransform(rotationAngle: .pi / 10)
-        midImageView.transform = CGAffineTransform(rotationAngle: -.pi / 10)
+        bottomView.transform = CGAffineTransform(rotationAngle: .pi / 10)
+        midView.transform = CGAffineTransform(rotationAngle: -.pi / 10)
+        
+        [topView, midView, bottomView].forEach { img in
+            img?.setLayout(radius: 30,
+                           shadowColor: .black,
+                           shadowOpacity: 0.4,
+                           shadowOffset: .zero,
+                           shadowRadius: 10)
+            img?._borderColor = .white
+            img?._borderWidth = 6
+        }
     }
     
     func config(_ item: SearchModel) {
-        topImageView.setImage(item.posterURL, nil) { [unowned self] img in
-            self.midImageView.image = img
-            self.bottomImageView.image = img
-        }
+        topView.setImage(item.posterURL)
+        midView.setImage(item.backdropURL)
+        bottomView.setImage(item.backdropURL)
         nameLabel.text = item.getTitle()
         dateLabel.text = item.getReleaseDate()
     }

--- a/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/View/Home/Cell/HomeItemCell.xib
+++ b/HN_Pra19_IOS_Movie_App/HN_Pra19_IOS_Movie_App/View/Home/Cell/HomeItemCell.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="HomeItemCell" customModule="TUANNM_MOVIE_21" customModuleProvider="target">
+        <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="HomeItemCell" customModule="HN_Pra19_IOS_Movie_App" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="215" height="275"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -44,102 +44,33 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cec-UZ-ePx">
                         <rect key="frame" x="0.0" y="20" width="215" height="136"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="CvN-Hs-vEv">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bSu-pe-MOd" customClass="ShadowImageView" customModule="HN_Pra19_IOS_Movie_App" customModuleProvider="target">
                                 <rect key="frame" x="43" y="13.666666666666664" width="129" height="108.66666666666669"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_cornerRadius">
-                                        <real key="value" value="30"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="_borderColor">
-                                        <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="_lShadowColor">
-                                        <color key="value" systemColor="systemGray6Color"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_borderWidth">
-                                        <real key="value" value="6"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="size" keyPath="_lShadowOffset">
-                                        <size key="value" width="0.0" height="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_lShadowOpacity">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_lShadowRadius">
-                                        <real key="value" value="0.0"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </imageView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GIK-Hp-8LS">
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LZa-nj-aPO" customClass="ShadowImageView" customModule="HN_Pra19_IOS_Movie_App" customModuleProvider="target">
                                 <rect key="frame" x="43" y="13.666666666666664" width="129" height="108.66666666666669"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_cornerRadius">
-                                        <real key="value" value="30"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="_borderColor">
-                                        <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="_lShadowColor">
-                                        <color key="value" systemColor="systemGray6Color"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_borderWidth">
-                                        <real key="value" value="6"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="size" keyPath="_lShadowOffset">
-                                        <size key="value" width="0.0" height="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_lShadowOpacity">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_lShadowRadius">
-                                        <real key="value" value="0.0"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </imageView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="wLV-LW-bjf">
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EXw-2w-sVc" customClass="ShadowImageView" customModule="HN_Pra19_IOS_Movie_App" customModuleProvider="target">
                                 <rect key="frame" x="43" y="13.666666666666664" width="129" height="108.66666666666669"/>
-                                <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_cornerRadius">
-                                        <real key="value" value="30"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="_borderColor">
-                                        <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="_lShadowColor">
-                                        <color key="value" systemColor="systemGray6Color"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_borderWidth">
-                                        <real key="value" value="6"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="size" keyPath="_lShadowOffset">
-                                        <size key="value" width="0.0" height="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_lShadowOpacity">
-                                        <real key="value" value="1"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="_lShadowRadius">
-                                        <real key="value" value="0.0"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </imageView>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="CvN-Hs-vEv" firstAttribute="bottom" secondItem="wLV-LW-bjf" secondAttribute="bottom" id="0fD-th-PfP"/>
-                            <constraint firstItem="wLV-LW-bjf" firstAttribute="centerY" secondItem="cec-UZ-ePx" secondAttribute="centerY" id="4iL-Ws-Zxn"/>
-                            <constraint firstItem="GIK-Hp-8LS" firstAttribute="trailing" secondItem="wLV-LW-bjf" secondAttribute="trailing" id="5Jk-o2-CCN"/>
-                            <constraint firstItem="CvN-Hs-vEv" firstAttribute="trailing" secondItem="wLV-LW-bjf" secondAttribute="trailing" id="8WI-29-pgB"/>
-                            <constraint firstItem="GIK-Hp-8LS" firstAttribute="top" secondItem="wLV-LW-bjf" secondAttribute="top" id="Gna-zm-0yl"/>
-                            <constraint firstItem="GIK-Hp-8LS" firstAttribute="bottom" secondItem="wLV-LW-bjf" secondAttribute="bottom" id="HGW-TX-s1Q"/>
-                            <constraint firstItem="wLV-LW-bjf" firstAttribute="width" secondItem="cec-UZ-ePx" secondAttribute="width" multiplier="0.6" id="Q4v-Ns-jbD"/>
-                            <constraint firstItem="wLV-LW-bjf" firstAttribute="height" secondItem="cec-UZ-ePx" secondAttribute="height" multiplier="0.8" id="THX-ka-xw1"/>
-                            <constraint firstItem="CvN-Hs-vEv" firstAttribute="top" secondItem="wLV-LW-bjf" secondAttribute="top" id="VIs-wb-Nrs"/>
-                            <constraint firstItem="wLV-LW-bjf" firstAttribute="centerX" secondItem="cec-UZ-ePx" secondAttribute="centerX" id="X1U-xj-tUU"/>
-                            <constraint firstItem="CvN-Hs-vEv" firstAttribute="leading" secondItem="wLV-LW-bjf" secondAttribute="leading" id="a10-me-apj"/>
-                            <constraint firstItem="GIK-Hp-8LS" firstAttribute="leading" secondItem="wLV-LW-bjf" secondAttribute="leading" id="evh-lu-kjD"/>
+                            <constraint firstItem="EXw-2w-sVc" firstAttribute="height" secondItem="cec-UZ-ePx" secondAttribute="height" multiplier="0.8" id="0Oc-Dq-OL8"/>
+                            <constraint firstItem="bSu-pe-MOd" firstAttribute="leading" secondItem="EXw-2w-sVc" secondAttribute="leading" id="0ZT-hl-Q2O"/>
+                            <constraint firstItem="EXw-2w-sVc" firstAttribute="centerY" secondItem="cec-UZ-ePx" secondAttribute="centerY" id="4x9-ib-Hhx"/>
+                            <constraint firstItem="bSu-pe-MOd" firstAttribute="bottom" secondItem="EXw-2w-sVc" secondAttribute="bottom" id="RmG-KC-LB7"/>
+                            <constraint firstItem="bSu-pe-MOd" firstAttribute="top" secondItem="EXw-2w-sVc" secondAttribute="top" id="SPk-K5-XeE"/>
+                            <constraint firstItem="LZa-nj-aPO" firstAttribute="leading" secondItem="EXw-2w-sVc" secondAttribute="leading" id="doj-sx-l6Y"/>
+                            <constraint firstItem="EXw-2w-sVc" firstAttribute="centerX" secondItem="cec-UZ-ePx" secondAttribute="centerX" id="g1j-LN-8MQ"/>
+                            <constraint firstItem="bSu-pe-MOd" firstAttribute="trailing" secondItem="EXw-2w-sVc" secondAttribute="trailing" id="kQj-WZ-d5p"/>
+                            <constraint firstItem="LZa-nj-aPO" firstAttribute="top" secondItem="EXw-2w-sVc" secondAttribute="top" id="mdy-pY-4bc"/>
+                            <constraint firstItem="LZa-nj-aPO" firstAttribute="bottom" secondItem="EXw-2w-sVc" secondAttribute="bottom" id="mho-lI-OAN"/>
+                            <constraint firstItem="EXw-2w-sVc" firstAttribute="width" secondItem="cec-UZ-ePx" secondAttribute="width" multiplier="0.6" id="nVv-Wl-G37"/>
+                            <constraint firstItem="LZa-nj-aPO" firstAttribute="trailing" secondItem="EXw-2w-sVc" secondAttribute="trailing" id="oe7-Vw-PGo"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -155,11 +86,11 @@
             </constraints>
             <size key="customSize" width="215" height="275"/>
             <connections>
-                <outlet property="bottomImageView" destination="CvN-Hs-vEv" id="Gmv-xg-oCd"/>
+                <outlet property="bottomView" destination="bSu-pe-MOd" id="abe-qR-ahS"/>
                 <outlet property="dateLabel" destination="sIJ-wJ-kiq" id="X99-hK-Ae1"/>
-                <outlet property="midImageView" destination="GIK-Hp-8LS" id="87o-PS-tbg"/>
+                <outlet property="midView" destination="LZa-nj-aPO" id="k67-Ul-U9t"/>
                 <outlet property="nameLabel" destination="34D-IV-xKc" id="rjZ-30-gd8"/>
-                <outlet property="topImageView" destination="wLV-LW-bjf" id="YXz-Nk-pYo"/>
+                <outlet property="topView" destination="EXw-2w-sVc" id="cGT-19-SFS"/>
             </connections>
             <point key="canvasLocation" x="191.6030534351145" y="98.943661971830991"/>
         </collectionViewCell>
@@ -168,8 +99,8 @@
         <namedColor name="color787575">
             <color red="0.47058823529411764" green="0.45882352941176469" blue="0.45882352941176469" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## Related Tickets
- [#Task 79074: fix bug UI home screen](https://edu-redmine.sun-asterisk.vn/issues/79074)
## WHAT
- Add shadow to image of  cell item  in home screen
## Evidence (Screenshot or Video)
<img width="351" alt="image" src="https://github.com/user-attachments/assets/8147609c-328b-4afe-b242-5ec89cd1f7fb">

## Review Checklist

Category | View Point | Description | Self review | Reviewer2 (name)
--- | --- | --- | --- | ---
Conventions | Sun* coding conventions | https://sal.vn/Zts4P8 |<li>- [ ] yes</li>|<li>- [ ] yes</li>
Message | Sun* commit message | Template: [TASK/FREATURE/BUG/SUPPORT][RedmineID] + message |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Sun* Redmine working process  | https://sal.vn/piPoQn |<li>- [ ] yes</li>|<li>- [ ] yes</li>  

## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*
